### PR TITLE
Handle invalid or empty pid files instead of returning pid 0

### DIFF
--- a/lib/daemons/pidfile.rb
+++ b/lib/daemons/pidfile.rb
@@ -103,9 +103,11 @@ module Daemons
 
     def pid
       begin
-        File.open(filename) {|f|
-          return f.gets.to_i
-        }
+        File.open(filename) do |f|
+          p = f.gets.to_i
+          return nil if p == 0 # Otherwise an invalid pid file becomes pid 0
+          return p
+        end
       rescue ::Exception
         return nil
       end


### PR DESCRIPTION
If the pid file is empty or contains non-numeric data, this function returns 0. That means an empty pid file results in a test for `kill(0, 0)` which always returns true, preventing Daemons from restarting a process that has failed in this way.
