### PR TITLE
Monitor pidfile is not be returned by PidFile.find_files

### DIFF
--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -94,14 +94,9 @@ module Daemons
     end
 
     def find_applications_by_pidfiles(dir)
-      pid_files = PidFile.find_files(dir, app_name, ! @keep_pid_files)
-
-      # pp pid_files
-
       @monitor = Monitor.find(dir, app_name + '_monitor')
 
-      pid_files.reject! { |f| f =~ /_monitor.pid$/ }
-
+      pid_files = PidFile.find_files(dir, app_name, ! @keep_pid_files)
       pid_files.map do |f|
         app = Application.new(self, {}, PidFile.existing(f))
         setup_app(app)


### PR DESCRIPTION
Since PR #12, the monitor pidfile does not get returned along with the workers anymore. This workaround code can be removed now.
