### PR TITLE
Allow custom status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,38 @@ end
 
 For further documentation, refer to the module documentation of Daemons.
 
+Displaying daemon status
+------------------------
+
+When daemonizing a process using a wrapper script, as examples 1 and 2 above,
+the status can be shown using
+
+``` ruby
+$ ruby myproc_control.rb status
+```
+
+By default this will display whether or not the daemon is running and, if it
+is, its PID.
+
+A custom message can be shown with
+
+``` ruby
+def custom_show_status(app)
+  # Display the default status information
+  app.default_show_status
+
+  puts
+  puts "PS information"
+  system("ps -p #{app.pid.pid.to_s}")
+
+  puts
+  puts "Size of log files"
+  system("du -hs /path/to/logs")
+end
+
+Daemons.run('myserver.rb', { show_status_callback: :custom_show_status })
+```
+
 Author
 ------
 

--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -130,6 +130,9 @@ module Daemons
     def setup_app(app)
       app.controller_argv = @controller_argv
       app.app_argv = @app_argv
+      if @options[:show_status_callback]
+        app.show_status_callback = @options[:show_status_callback]
+      end
     end
     private :setup_app
 


### PR DESCRIPTION
I would like to be able to display extra information when checking the status of a daemon. I have done this by adding an option to Daemons.run for a callback function to be used then the status is requested. I have added a section to the README.md to explain further.
