### PR TITLE
ApplicationGroup should wait on subprocesses in start_all

### DIFF
--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -146,11 +146,13 @@ module Daemons
       @monitor.stop if @monitor
       @monitor = nil
 
+      pids = []
       @applications.each do |a|
-        fork do
+        pids << fork do
           a.start
         end
       end
+      pids.each { |pid| Process.waitpid(pid) }
     end
 
     def stop_all(no_wait = false)


### PR DESCRIPTION
I encountered this race condition while using `Capistrano` in combination with `daemons` to deploy my background processes.
`Daemons` forks new subprocesses for each `Application` it starts as a daemon, but doesn't wait for these subprocesses to finish. So when restarting the daemon, the "main" process (created by command line invocation requesting a restart) terminates early, although all `Application`'s might not be started yet (since this is happening in subprocesses). In combination with `Capistrano` this causes the SSH connection to be closed and `SIGHUP` gets sent to all processes started by `daemons`, causing them to quit immediately.
This is not specific to `Capistrano`, but probably the easiest way to reproduce, because of the necessary timing.
In my environment this leads to PID files not being written (using Application.start_proc), although my daemon was started. Depending on the timing other things could happen.