### PR TITLE
Extracted all output messages to a Reporter class

### DIFF
--- a/lib/daemons/application.rb
+++ b/lib/daemons/application.rb
@@ -3,6 +3,7 @@ require 'daemons/pidmem'
 require 'daemons/change_privilege'
 require 'daemons/daemonize'
 require 'daemons/exceptions'
+require 'daemons/reporter'
 
 require 'timeout'
 
@@ -33,6 +34,8 @@ module Daemons
 
       @show_status_callback = method(:default_show_status)
 
+      @report = Reporter.new(@options)
+
       unless @pid = pid
         if @options[:no_pidfiles]
           @pid = PidMem.new
@@ -51,7 +54,10 @@ module Daemons
     def change_privilege
       user = options[:user]
       group = options[:group]
-      CurrentProcess.change_privilege(user, group) if user
+      if user
+        @report.changing_process_privilege(user, group)
+        CurrentProcess.change_privilege(user, group)
+      end
     end
 
     def script
@@ -139,7 +145,7 @@ module Daemons
 
     def start_exec
       if options[:backtrace]
-        puts 'option :backtrace is not supported with :mode => :exec, ignoring'
+        @report.backtrace_not_supported
       end
 
       unless options[:ontop]
@@ -300,8 +306,7 @@ module Daemons
 
     def started
       if pid = @pid.pid
-        puts "#{group.app_name}: process with pid #{pid} started."
-        STDOUT.flush
+        @report.process_started(group.app_name, pid)
       end
     end
 
@@ -373,13 +378,13 @@ module Daemons
       begin
         Process.kill(SIGNAL, pid)
       rescue Errno::ESRCH => e
-        puts "#{e} #{pid}"
-        puts 'deleting pid-file.'
+        @report.output_message("#{e} #{pid}")
+        @report.output_message('deleting pid-file.')
       end
 
       unless no_wait
         if @force_kill_waittime > 0
-          puts "#{group.app_name}: trying to stop process with pid #{pid}..."
+          @report.stopping_process(group.app_name, pid)
           STDOUT.flush
 
           begin
@@ -389,7 +394,7 @@ module Daemons
               end
             end
           rescue TimeoutError
-            puts "#{group.app_name}: process with pid #{pid} won't stop, we forcefully kill it..."
+            @report.forcefully_stopping_process(group.app_name, pid)
             STDOUT.flush
 
             begin
@@ -404,7 +409,7 @@ module Daemons
                 end
               end
             rescue TimeoutError
-              puts "#{group.app_name}: unable to forcefully kill process with pid #{pid}."
+              @report.cannot_stop_process(group.app_name, pid)
               STDOUT.flush
             end
           end
@@ -418,7 +423,7 @@ module Daemons
         # didn't clean it up.
         begin; @pid.cleanup; rescue ::Exception; end
 
-        puts "#{group.app_name}: process with pid #{pid} successfully stopped."
+        @report.stopped_process
         STDOUT.flush
       end
     end
@@ -438,7 +443,7 @@ module Daemons
     def default_show_status(daemon = self)
       running = daemon.running?
 
-      puts "#{group.app_name}: #{running ? '' : 'not '}running#{(running and daemon.pid.exist?) ? ' [pid ' + daemon.pid.pid.to_s + ']' : ''}#{(daemon.pid.exist? and not running) ? ' (but pid-file exists: ' + daemon.pid.pid.to_s + ')' : ''}"
+      @report.status(group.app_name, running, daemon.pid.exist?, daemon.pid.pid.to_s)
     end
 
     # This function implements a (probably too simle) method to detect

--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -90,7 +90,11 @@ module Daemons
     def find_applications_by_pidfiles(dir)
       @monitor = Monitor.find(dir, app_name + '_monitor')
 
-      pid_files = PidFile.find_files(dir, app_name, ! @keep_pid_files)
+      reporter = Reporter.new(options)
+      pid_files = PidFile.find_files(dir, app_name, ! @keep_pid_files) do |pid, file| 
+        reporter.deleted_found_pidfile(pid, file)
+      end
+
       pid_files.map do |f|
         app = Application.new(self, {}, PidFile.existing(f))
         setup_app(app)

--- a/lib/daemons/change_privilege.rb
+++ b/lib/daemons/change_privilege.rb
@@ -2,8 +2,6 @@ require 'daemons/etc_extension'
 
 class CurrentProcess
   def self.change_privilege(user, group = user)
-    puts "Changing process privilege to #{user}:#{group}"
-
     uid, gid = Process.euid, Process.egid
     target_uid = Etc.getpwnam(user).uid
     target_gid = Etc.getgrnam(group).gid

--- a/lib/daemons/pidfile.rb
+++ b/lib/daemons/pidfile.rb
@@ -40,8 +40,8 @@ module Daemons
           pid = File.open(f) { |h| h.read }.to_i
           rsl =  !Pid.running?(pid)
           if rsl
-            puts "pid-file for killed process #{pid} found (#{f}), deleting."
             begin; File.unlink(f); rescue ::Exception; end
+            yield(pid, f) if block_given?
           end
           rsl
         end

--- a/lib/daemons/reporter.rb
+++ b/lib/daemons/reporter.rb
@@ -37,7 +37,7 @@ module Daemons
     end
 
     def forcefully_stopping_process(app_name, pid)
-      putput_message "#{app_name}: process with pid #{pid} won't stop, we forcefully kill it..." 
+      output_message "#{app_name}: process with pid #{pid} won't stop, we forcefully kill it..." 
     end
 
     def cannot_stop_process(app_name, pid)

--- a/lib/daemons/reporter.rb
+++ b/lib/daemons/reporter.rb
@@ -1,0 +1,55 @@
+module Daemons
+  class Reporter
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+
+      if !options[:shush]
+        $stdout.sync = true
+      end
+    end
+
+    def output_message(message)
+      if !options[:shush]
+        puts message
+      end
+    end
+
+    def changing_process_privilege(user, group = user)
+      output_message "Changing process privilege to #{user}:#{group}"
+    end
+
+    def deleted_found_pidfile(pid, f)
+      output_message "pid-file for killed process #{pid} found (#{f}), deleting."
+    end
+
+    def process_started(app_name, pid)
+      output_message  "#{app_name}: process with pid #{pid} started."
+    end
+
+    def backtrace_not_supported 
+      output_message 'option :backtrace is not supported with :mode => :exec, ignoring'
+    end
+
+    def stopping_process(app_name, pid)
+      output_message "#{app_name}: trying to stop process with pid #{pid}..."
+    end
+
+    def forcefully_stopping_process(app_name, pid)
+      putput_message "#{app_name}: process with pid #{pid} won't stop, we forcefully kill it..." 
+    end
+
+    def cannot_stop_process(app_name, pid)
+      output_message "#{app_name}: unable to forcefully kill process with pid #{pid}."
+    end
+
+    def stopped_process(app_name, pid)
+      output_message "#{app_name}: process with pid #{pid} successfully stopped."
+    end
+
+    def status(app_name, running, pid_exists, pid)
+      output_message "#{group.app_name}: #{running ? '' : 'not '}running#{(running and daemon.pid.exist?) ? ' [pid ' + daemon.pid.pid.to_s + ']' : ''}#{(daemon.pid.exist? and not running) ? ' (but pid-file exists: ' + daemon.pid.pid.to_s + ')' : ''}"
+    end
+  end
+end


### PR DESCRIPTION
Supporting a usecase for silencing output messages. A ‘:shush’ options can be set to true to enable a silent mode. By default :shush is nil and so the silent mode won’t be turned on for existing usecases, unless explicitly set to true in options. stdout sync is set to true to avoid buffering.