### PR TITLE
Allow to set pid location when using system mode

### DIFF
--- a/lib/daemons/pid.rb
+++ b/lib/daemons/pid.rb
@@ -39,7 +39,7 @@ module Daemons
         when :script
           return File.expand_path(File.join(File.dirname(script), dir))
         when :system
-          return '/var/run'
+          return dir || '/var/run'
         else
           fail Error.new("pid file mode '#{dir_mode}' not implemented")
       end
@@ -65,7 +65,7 @@ module Daemons
     # Cleanup method
     def cleanup
     end
-    
+
     # Zap method
     def zap
     end


### PR DESCRIPTION
Users are not allowed to put files in `/var/run` ( tested on debian, archlinux ) so it's better to let a chance to setup custom location :)