### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+script: bundle exec rspec --format documentation
+language: ruby
+sudo: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+matrix:
+  include:
+    - rvm: 2.0.0
+      os: osx


### PR DESCRIPTION
Now that there are unit tests, Travis CI provides a free public testing service: http://docs.travis-ci.com/user/getting-started/