### PR TITLE
⚠️ assigned but unused variable - restart, sess_id, pid

### DIFF
--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -69,7 +69,7 @@ module Daemons
         if x && x.chomp!
           processes = x.split(/\n/).compact
           processes = processes.delete_if do |p|
-            pid, name, add = p.split(/\s/)
+            _pid, name, add = p.split(/\s/)
             # We want to make sure that the first part of the process name matches
             # so that app_name matches app_name_22
 

--- a/lib/daemons/daemonize.rb
+++ b/lib/daemons/daemonize.rb
@@ -58,7 +58,7 @@ module Daemonize
       rd.close
 
       # Detach from the controlling terminal
-      unless sess_id = Process.setsid
+      unless Process.setsid
         fail Daemons.RuntimeException.new('cannot detach from controlling terminal')
       end
 
@@ -100,7 +100,7 @@ module Daemonize
 
     # Prevent the possibility of acquiring a controlling terminal
     trap 'SIGHUP', 'IGNORE'
-    exit if pid = safefork
+    exit if safefork
 
     $0 = app_name if app_name
 

--- a/lib/daemons/monitor.rb
+++ b/lib/daemons/monitor.rb
@@ -46,7 +46,7 @@ module Daemons
 
             sleep(1)
 
-            Process.detach(fork { a.start(restart = true) })
+            Process.detach(fork { a.start(true) })
 
             sleep(5)
           end


### PR DESCRIPTION
This patch eliminates some Ruby warnings concerning unused variable.