### PR TITLE
Call zap, not cleanup on the pidfile

### DIFF
--- a/lib/daemons/application.rb
+++ b/lib/daemons/application.rb
@@ -416,7 +416,7 @@ module Daemons
       unless Pid.running?(pid)
         # We try to remove the pid-files by ourselves, in case the application
         # didn't clean it up.
-        begin; @pid.cleanup; rescue ::Exception; end
+        zap!
 
         @report.stopped_process(group.app_name, pid)
         $stdout.flush


### PR DESCRIPTION
## Problem

When stopping a running application, pidfile#cleanup does not remove the pid file.

## Use Case
Starting a daemon from a ctl wrapper
```
# my_ctl
Daemons.run_proc('my_app') do
  # do some stuff
end
```
Start and stop my_app
```
./my_ctl start
./my_ctl stop
```

The pidfile will not be removed because the process you just executed is not the same as the process you are trying to clean up. As a matter of fact, I do not think that clean up will ever do anything. It is in a block conditional on the pid being stopped. `unless Pid.running?(pid)` So this code is not reachable from within the same process as you are trying to clean up.

## Solution

Call zap here instead if we really want to clean up the pidfile, and I think that we do. 

## Review Checklist

During code review, make sure to check for the following:
* [ ] Confirm that this is the behaviour that we want
* [ ] Does not break old use cases
* [ ] Relevant tests?