### PR TITLE
Fixed two simple pidfile errors

### DIFF
--- a/lib/daemons.rb
+++ b/lib/daemons.rb
@@ -251,6 +251,7 @@ module Daemons
     options[:app_name] ||= 'proc'
     options[:proc] = Proc.new
     options[:mode] = :proc
+    options[:dir_mode] = :normal
 
     @group ||= ApplicationGroup.new(options[:app_name], options)
 

--- a/lib/daemons/pidfile.rb
+++ b/lib/daemons/pidfile.rb
@@ -100,9 +100,9 @@ module Daemons
     end
 
     def zap
-      File.delete(filename)
+      File.delete(filename) if exist?
     end
-    
+
     def pid
       begin
         File.open(filename) do |f|


### PR DESCRIPTION
Exception throw is pretty self explanatory. The file mode change is important because creating a deamon with call or new has no script file so it has to use the dir option for pidfile location. The default is to use current directory since options[:dir] defaults to '' in application_group and File.expand_path '' returns current directory.