### PR TITLE
pass +no_wait+ option also on restart

### DIFF
--- a/lib/daemons/controller.rb
+++ b/lib/daemons/controller.rb
@@ -61,7 +61,7 @@ module Daemons
           @group.stop_all(@options[:no_wait])
         when 'restart'
           unless @group.applications.empty?
-            @group.stop_all
+            @group.stop_all(@options[:no_wait])
             sleep(1)
             @group.start_all
           else


### PR DESCRIPTION
Hi,
I would like to use the no_wait option also on restart. 
So running processes may finish work while new processes are already started.

