### PR TITLE
Allow status callback to be anything callable

### DIFF
--- a/lib/daemons/application.rb
+++ b/lib/daemons/application.rb
@@ -52,7 +52,12 @@ module Daemons
     end
 
     def show_status_callback=(function)
-      @show_status_callback = method(function)
+      @show_status_callback = 
+        if function.respond_to?(:call)
+          function
+        else
+          method(function)
+        end
     end
 
     def change_privilege


### PR DESCRIPTION
this allows for non-global methods (eg. when using in a class) or Procs