### PR TITLE
add support for log-related command line params

### DIFF
--- a/lib/daemons/cmdline.rb
+++ b/lib/daemons/cmdline.rb
@@ -12,7 +12,7 @@ module Daemons
         opts.on('-t', '--ontop', 'Stay on top (does not daemonize)') do |t|
           @options[:ontop] = t
         end
-        
+
         opts.on('-s', '--shush', 'Silent mode (no output to the terminal)') do |t|
           @options[:shush] = t
         end
@@ -31,6 +31,26 @@ module Daemons
 
         opts.separator ''
         opts.separator 'Common options:'
+
+        opts.on('-l', '--log_output', 'Enable input/output stream redirection') do |value|
+          @options[:log_output] = value
+        end
+
+        opts.on('--logfilename FILE', String, 'Custom log file name for exceptions') do |value|
+          @options[:logfilename] = value
+        end
+
+        opts.on('--output_logfilename FILE', String, 'Custom file name for input/output stream redirection log') do |value|
+          @options[:output_logfilename] = value
+        end
+
+        opts.on('--log_dir DIR', String, 'Directory for log files') do |value|
+          @options[:log_dir] = value
+        end
+
+        opts.on('--syslog', 'Enable redirect output into SYSLOG instead of the file') do |value|
+          @options[:log_output_syslog] = value
+        end
 
         # No argument, shows at tail.  This will print an options summary
         opts.on_tail('-h', '--help', 'Show this message') do
@@ -66,7 +86,7 @@ END
     def parse(args)
       # The options specified on the command line will be collected in *options*.
       # We set default values here.
-      
+
       @opts.parse(args)
 
       @options

--- a/spec/lib/daemons/optparse_spec.rb
+++ b/spec/lib/daemons/optparse_spec.rb
@@ -17,6 +17,7 @@ describe Daemons::Optparse do
       {given: ["--force"],                      expect: {force: true}},
       {given: ["-n"],                           expect: {no_wait: true}},
       {given: ["--no_wait"],                    expect: {no_wait: true}},
+      {given: ["--force_kill_waittime", "42"],  expect: {force_kill_waittime: 42}},
       {given: ["-l"],                           expect: {log_output: true}},
       {given: ["--log_output"],                 expect: {log_output: true}},
       {given: ["--logfilename", "FILE"],        expect: {logfilename: "FILE"}},
@@ -24,12 +25,18 @@ describe Daemons::Optparse do
       {given: ["--log_dir", "/dir/"],           expect: {log_dir: "/dir/"}},
       {given: ["--syslog"],                     expect: {log_output_syslog: true}},
       {given: [
-          "-t", "-s", "-f", "-n", "-l", "--logfilename", "LF", "--output_logfilename", "OLF", "--log_dir", "/dir/", "--syslog"
+          "-t", "-s", "-f", "-n",
+          "--force_kill_waittime", "42",
+          "-l", "--logfilename", "LF",
+          "--output_logfilename", "OLF",
+          "--log_dir", "/dir/",
+          "--syslog"
         ], expect: {
           ontop: true,
           shush: true,
           force: true,
           no_wait: true,
+          force_kill_waittime: 42,
           log_output: true,
           log_output_syslog: true,
           logfilename: "LF",

--- a/spec/lib/daemons/optparse_spec.rb
+++ b/spec/lib/daemons/optparse_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Daemons::Optparse do
+
+  let(:controller) { Daemons::Controller.new }
+  subject(:optparse) { described_class.new(controller) }
+
+  describe "#parse" do
+    subject { optparse.parse(args) }
+    [
+      {given: [],                               expect: {}},
+      {given: ["-t"],                           expect: {ontop: true}},
+      {given: ["--ontop"],                      expect: {ontop: true}},
+      {given: ["-s"],                           expect: {shush: true}},
+      {given: ["--shush"],                      expect: {shush: true}},
+      {given: ["-f"],                           expect: {force: true}},
+      {given: ["--force"],                      expect: {force: true}},
+      {given: ["-n"],                           expect: {no_wait: true}},
+      {given: ["--no_wait"],                    expect: {no_wait: true}},
+      {given: ["-l"],                           expect: {log_output: true}},
+      {given: ["--log_output"],                 expect: {log_output: true}},
+      {given: ["--logfilename", "FILE"],        expect: {logfilename: "FILE"}},
+      {given: ["--output_logfilename", "FILE"], expect: {output_logfilename: "FILE"}},
+      {given: ["--log_dir", "/dir/"],           expect: {log_dir: "/dir/"}},
+      {given: ["--syslog"],                     expect: {log_output_syslog: true}},
+      {given: [
+          "-t", "-s", "-f", "-n", "-l", "--logfilename", "LF", "--output_logfilename", "OLF", "--log_dir", "/dir/", "--syslog"
+        ], expect: {
+          ontop: true,
+          shush: true,
+          force: true,
+          no_wait: true,
+          log_output: true,
+          log_output_syslog: true,
+          logfilename: "LF",
+          output_logfilename: "OLF",
+          log_dir: "/dir/"
+        }
+      }
+    ].each do |test_options|
+      context "with #{test_options[:given]}" do
+        let(:args) { test_options[:given] }
+        it "returns correctly parsed options" do
+          expect(subject).to eql test_options[:expect]
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Daemons has grown a range of useful configuration options, but not all are exposed for command line control. This change adds command line support for them all.

I needed this in particular for some log file redirection, and its been in production for over a year(!) but I seem to never have got around to sending over a PR.