### PR TITLE
Fix undefined local variable or method `pid_delimiter'

### DIFF
--- a/daemons.gemspec
+++ b/daemons.gemspec
@@ -3,7 +3,6 @@ require File.expand_path('../lib/daemons/version', __FILE__)
 Gem::Specification.new do |s|
   s.name = %q{daemons}
   s.version = Daemons::VERSION
-  s.date = %q{2017-12-24}
   s.authors = ["Thomas Uehlinger"]
   s.license = "MIT"
   s.email = %q{thomas.uehinger@gmail.com}

--- a/lib/daemons/pidfile.rb
+++ b/lib/daemons/pidfile.rb
@@ -29,7 +29,7 @@ module Daemons
   #
   class PidFile < Pid
     DEFAULT_PID_DELIMITER = '_num'
-    attr_reader :dir, :progname, :multiple, :number
+    attr_reader :dir, :progname, :multiple, :number, :pid_delimiter
 
     def self.find_files(dir, progname, delete = false, pid_delimiter = nil)
       files = Dir[File.join(dir, "#{progname}#{pid_delimiter || DEFAULT_PID_DELIMITER}*.pid")]

--- a/spec/lib/daemons/application_spec.rb
+++ b/spec/lib/daemons/application_spec.rb
@@ -77,6 +77,13 @@ module Daemons
             subject
           end
         end
+        context 'group with multiple processes is provided' do
+          let(:group) { ApplicationGroup.new app_name, multiple: true }
+
+          it 'uses the number in filename' do
+            expect(subject.filename).to eq "/var/run/#{group.app_name}_num0.pid"
+          end
+        end
       end
     end
 


### PR DESCRIPTION
With using group.multiple, the daemons were failing with:

```
NameError: undefined local variable or method `pid_delimiter' for
#<Daemons::PidFile:0x000055fa9e83c748> Did you mean?  @pid_delimiter
 daemons-1.3.0/lib/daemons/pidfile.rb:86:in `filename'
 daemons-1.3.0/lib/daemons/pidfile.rb:75:in `initialize'
 daemons-1.3.0/lib/daemons/application.rb:47:in `new'
 daemons-1.3.0/lib/daemons/application.rb:47:in `initialize'
 daemons-1.3.0/lib/daemons/application_group.rb:125:in `new'
 daemons-1.3.0/lib/daemons/application_group.rb:125:in `new_application'
 daemons-1.3.0/lib/daemons/controller.rb:56:in `run'
 daemons-1.3.0/lib/daemons.rb:199:in `block in run_proc'
 daemons-1.3.0/lib/daemons/cmdline.rb:121:in `catch_exceptions'
```

Also, remove date from gemspec. Otherwise, recent release on rubygems.org looks
like it was done a year ago. I don't think there is any use in having it in the
specfile compared to the risk of forgetting to update it.