### PR TITLE
Resolves mismatched indentations

### DIFF
--- a/lib/daemons/application.rb
+++ b/lib/daemons/application.rb
@@ -203,7 +203,7 @@ module Daemons
           if $daemons_stop_proc
             $daemons_stop_proc.call
           end
-          rescue ::Exception
+        rescue ::Exception
         end
 
         begin; @pid.cleanup; rescue ::Exception; end
@@ -260,7 +260,7 @@ module Daemons
             if $daemons_stop_proc
               $daemons_stop_proc.call
             end
-            rescue ::Exception
+          rescue ::Exception
           end
 
           begin; @pid.cleanup; rescue ::Exception; end

--- a/lib/daemons/application_group.rb
+++ b/lib/daemons/application_group.rb
@@ -83,7 +83,7 @@ module Daemons
           end
           pids = processes.map { |p| p.split(/\s/)[0].to_i }
         end
-        rescue ::Exception
+      rescue ::Exception
       end
 
       pids.map do |f|


### PR DESCRIPTION
The mismatched indentations caused noisy warnings in `rake test` of any repository using this gem