### PR TITLE
Allow to use pry-byebug 3.8.0

### DIFF
--- a/daemons.gemspec
+++ b/daemons.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |s|
   s.metadata = {
     "documentation_uri" => "http://www.rubydoc.info/gems/daemons",
   }
-  
+
   s.files = `git ls-files README.md LICENSE Releases lib examples`.split
 
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'simplecov', '~> 0'
-  s.add_development_dependency 'pry-byebug', '~> 3.0.0'
+  s.add_development_dependency 'pry-byebug', '~> 3.0'
 end


### PR DESCRIPTION
`s.add_development_dependency 'pry-byebug', '~> 3.0.0'` locks pry-byebug
version to 3.0.1 (February 04, 2015) which is pretty old version.

https://rubygems.org/gems/pry-byebug/versions