### PR TITLE
customize which signals are sent to stop process

### DIFF
--- a/lib/daemons/cmdline.rb
+++ b/lib/daemons/cmdline.rb
@@ -28,6 +28,9 @@ module Daemons
         opts.on('-w', '--force_kill_waittime SECONDS', Integer, 'Maximum time to wait for processes to stop before force-killing') do |t|
           @options[:force_kill_waittime] = t
         end
+        opts.on('--signals_and_waits STRING', String, 'which signal to use to stop and how long to wait e.g. TERM:20|KILL:20') do |t|
+          @options[:signals_and_waits] = t
+        end
 
         opts.on('--pid_delimiter STRING', 'Text used to separate process number in full process name and pid-file name') do |value|
           @options[:pid_delimiter] = value

--- a/lib/daemons/reporter.rb
+++ b/lib/daemons/reporter.rb
@@ -32,20 +32,19 @@ module Daemons
       output_message 'option :backtrace is not supported with :mode => :exec, ignoring'
     end
 
-    def stopping_process(app_name, pid)
-      output_message "#{app_name}: trying to stop process with pid #{pid}..."
-    end
-
-    def forcefully_stopping_process(app_name, pid)
-      output_message "#{app_name}: process with pid #{pid} won't stop, we forcefully kill it..." 
+    def stopping_process(app_name, pid, sig, wait)
+      output_message "#{app_name}: trying to stop process with pid #{pid}#{' forcefully :(' if sig == 'KILL'} sending #{sig} and waiting #{wait}s ..."
+      $stdout.flush
     end
 
     def cannot_stop_process(app_name, pid)
       output_message "#{app_name}: unable to forcefully kill process with pid #{pid}."
+      $stdout.flush
     end
 
     def stopped_process(app_name, pid)
       output_message "#{app_name}: process with pid #{pid} successfully stopped."
+      $stdout.flush
     end
 
     def status(app_name, running, pid_exists, pid)

--- a/spec/lib/daemons/optparse_spec.rb
+++ b/spec/lib/daemons/optparse_spec.rb
@@ -19,6 +19,7 @@ describe Daemons::Optparse do
       {given: ["--no_wait"],                    expect: {no_wait: true}},
       {given: ["--pid_delimiter", "a.b"],       expect: {pid_delimiter: "a.b"}},
       {given: ["--force_kill_waittime", "42"],  expect: {force_kill_waittime: 42}},
+      {given: ["--signals_and_waits", "TERM:20|KILL:20"],  expect: {signals_and_waits: "TERM:20|KILL:20"}},
       {given: ["-l"],                           expect: {log_output: true}},
       {given: ["--log_output"],                 expect: {log_output: true}},
       {given: ["--logfilename", "FILE"],        expect: {logfilename: "FILE"}},


### PR DESCRIPTION
For `stop`, user can now optionally set which signals are sent in which order.
eg `--signals_and_waits=TERM:10|KILL:20` is sending TERM and waiting 10s, then sending KILL and waiting 20s.
Default ist `TERM:20|KILL:20` as before

For example, this is useful in combination with delayed_job, where we override the start script "script/delayed_job" to give the workers more time to stop properly:

``` ruby
#!/usr/bin/env ruby

require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
require 'delayed/command'

class Daemons::Application
  alias_method :original_stop, :stop
  def stop(no_wait = false)
    @signals_and_waits = [
      { sig: 'INT', wait:  20 },
      { sig: 'TERM', wait: 20 },
      { sig: 'KILL', wait: 20 }
    ]

    original_stop(no_wait)
  end
end

Delayed::Command.new(ARGV).daemonize

```