### PR TITLE
Explicitly pass `&block` to `Proc.new`

### DIFF
--- a/lib/daemons.rb
+++ b/lib/daemons.rb
@@ -251,7 +251,7 @@ module Daemons
     fail 'Daemons.call: no block given' unless block_given?
 
     options[:app_name] ||= 'proc'
-    options[:proc] = Proc.new
+    options[:proc] = Proc.new(&block)
     options[:mode] = :proc
     options[:dir_mode] = :normal
 


### PR DESCRIPTION
Without this, `ruby examples/call/call.rb` fails with `tried to create Proc object without a block (ArgumentError)`.