### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Tests for (${{ matrix.ruby }} on ${{ matrix.os }})
+    strategy:
+      matrix:
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, head ]
+        os: [ ubuntu-latest ]
+        include:
+          - os: macos-latest
+            ruby: 2.4
+          - os: macos-latest
+            ruby: 2.5
+          - os: macos-latest
+            ruby: 2.6
+          - os: macos-latest
+            ruby: 2.7
+          - os: macos-latest
+            ruby: 3.0
+          - os: macos-latest
+            ruby: 3.1
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rspec

--- a/daemons.gemspec
+++ b/daemons.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'simplecov', '~> 0'
-  s.add_development_dependency 'pry-byebug', '~> 3.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
As the Travis CI.org service is no longer available, this PR migrates the CI to GitHub Actions.

It also adds a couple of Ruby releases - 3.0 and 3.1 - to the CI matrix.

Because Pry is no longer compatible with Ruby head, and is not the "standard" debugger going forward, I also remove `pry-byebug` from the Gemfile and removed the corresponding require.

This should all run green.